### PR TITLE
Add functionality to ignore certain types of setters

### DIFF
--- a/src/Fluency.Tests/BuilderTests/IgnoreNonPublicSetters.cs
+++ b/src/Fluency.Tests/BuilderTests/IgnoreNonPublicSetters.cs
@@ -1,0 +1,61 @@
+using Machine.Specifications;
+using SharpTestsEx;
+
+namespace Fluency.Tests.BuilderTests
+{
+    public class IgnoreNonPublicSetters
+    {
+        private class AClassWithNonPublicSetters
+        {
+            public string PropertyWithPrivateSetter { get; private set; }
+            public string PropertyWithProtectedSetter { get; protected set; }
+            public string PropertyWithInternalSetter { get; internal set; }
+            public string PropertyWithPublicSetter { get; set; }
+        }
+
+        [Subject("FluencyIgnoreProperties")]
+        public class When_builder_is_configured_to_ignore_non_public_setters : IgnorePropertySpecs
+        {
+            private It should_not_populate_private_setters = () =>
+            {
+                var builder = new FluentBuilder<AClassWithNonPublicSetters>();
+                builder.IgnoreNonPublicSetters();
+
+                var instance = builder.build();
+
+                instance.PropertyWithPrivateSetter.Should().Be(null);
+            };
+
+            private It should_not_populate_protected_setters = () =>
+            {
+                var builder = new FluentBuilder<AClassWithNonPublicSetters>();
+                builder.IgnoreNonPublicSetters();
+
+                var instance = builder.build();
+
+                instance.PropertyWithProtectedSetter.Should().Be(null);
+            };
+
+            private It should_not_populate_internal_setters = () =>
+            {
+                var builder = new FluentBuilder<AClassWithNonPublicSetters>();
+                builder.IgnoreNonPublicSetters();
+
+                var instance = builder.build();
+
+                instance.PropertyWithInternalSetter.Should().Be(null);
+            };
+
+            private It should_still_call_public_setters = () =>
+            {
+                var builder = new FluentBuilder<AClassWithNonPublicSetters>();
+                builder.IgnoreNonPublicSetters();
+
+                var instance = builder.build();
+
+                instance.PropertyWithPublicSetter.Should().Not.Be(null);
+                instance.PropertyWithPublicSetter.Should().Not.Be(string.Empty);
+            };
+        }
+    }
+}

--- a/src/Fluency.Tests/BuilderTests/IgnorePropertySpecs.cs
+++ b/src/Fluency.Tests/BuilderTests/IgnorePropertySpecs.cs
@@ -67,5 +67,22 @@ namespace Fluency.Tests.BuilderTests
                 instance.PropertyBSetterCalled.Should().Be(false);
             };
         }
+
+        [Subject("FluencyIgnoreProperties")]
+        public class When_builder_is_configured_to_ignore_all_properties : IgnorePropertySpecs
+        {
+            Establish context = () => Fluency.Initialize(x => x.IdGeneratorIsConstructedBy(() => new DecrementingIdGenerator()));
+
+            private It should_not_call_setter_for_any_property = () =>
+            {
+                var builder = new FluentBuilder<AClassWithTwoProperties>();
+                builder.IgnoreAllProperties();
+
+                var instance = builder.build();
+
+                instance.PropertyASetterCalled.Should().Be(false);
+                instance.PropertyBSetterCalled.Should().Be(false);
+            };
+        }
     }
 }

--- a/src/Fluency.Tests/BuilderTests/IgnorePropertySpecs.cs
+++ b/src/Fluency.Tests/BuilderTests/IgnorePropertySpecs.cs
@@ -1,0 +1,71 @@
+using Fluency.IdGenerators;
+using Machine.Specifications;
+using Rhino.Mocks.Constraints;
+using SharpTestsEx;
+
+namespace Fluency.Tests.BuilderTests
+{
+    public class IgnorePropertySpecs
+    {
+        private class AClassWithTwoProperties
+        {
+            public bool PropertyASetterCalled;
+            public bool PropertyBSetterCalled;
+            private string _propertyA;
+            private string _propertyB;
+
+            public string PropertyA
+            {
+                get { return _propertyA; }
+                set
+                {
+                    PropertyASetterCalled = true;
+                    _propertyA = value;
+                }
+            }
+
+            public string PropertyB
+            {
+                get { return _propertyB; }
+                set
+                {
+                    PropertyBSetterCalled = true;
+                    _propertyB = value;
+                }
+            }
+        }
+
+        [Subject("FluencyIgnoreProperties")]
+        public class When_builder_is_not_configured_to_ignore_any_property : IgnorePropertySpecs
+        {
+            Establish context = () => Fluency.Initialize(x => x.IdGeneratorIsConstructedBy(() => new DecrementingIdGenerator()));
+
+            private It should_populate_all_properties = () =>
+            {
+                var builder = new FluentBuilder<AClassWithTwoProperties>();
+
+                var instance = builder.build();
+
+                instance.PropertyASetterCalled.Should().Be(true);
+                instance.PropertyBSetterCalled.Should().Be(true);
+            };
+        }
+
+        [Subject("FluencyIgnoreProperties")]
+        public class When_builder_is_configured_to_ignore_a_property : IgnorePropertySpecs
+        {
+            Establish context = () => Fluency.Initialize(x => x.IdGeneratorIsConstructedBy(() => new DecrementingIdGenerator()));
+
+            private It should_not_call_setter_for_ignored_property = () =>
+            {
+                var builder = new FluentBuilder<AClassWithTwoProperties>();
+                builder.IgnoreProperty(x => x.PropertyB);
+
+                var instance = builder.build();
+
+                instance.PropertyASetterCalled.Should().Be(true);
+                instance.PropertyBSetterCalled.Should().Be(false);
+            };
+        }
+    }
+}

--- a/src/Fluency.Tests/Fluency.Tests.csproj
+++ b/src/Fluency.Tests/Fluency.Tests.csproj
@@ -90,6 +90,7 @@
   <ItemGroup>
     <Compile Include="AssertionExtensions.cs" />
     <Compile Include="BuilderTests\DynamicFluentBuilderSpecs.cs" />
+    <Compile Include="BuilderTests\IgnoreNonPublicSetters.cs" />
     <Compile Include="BuilderTests\IgnorePropertySpecs.cs" />
     <Compile Include="BuilderTests\Using_a_custom_builder_as_an_alias_for_an_existing_instance.cs" />
     <Compile Include="BuilderTests\Using_a_custom_builder_to_work_with_a_list_property.cs" />

--- a/src/Fluency.Tests/Fluency.Tests.csproj
+++ b/src/Fluency.Tests/Fluency.Tests.csproj
@@ -90,6 +90,7 @@
   <ItemGroup>
     <Compile Include="AssertionExtensions.cs" />
     <Compile Include="BuilderTests\DynamicFluentBuilderSpecs.cs" />
+    <Compile Include="BuilderTests\IgnorePropertySpecs.cs" />
     <Compile Include="BuilderTests\Using_a_custom_builder_as_an_alias_for_an_existing_instance.cs" />
     <Compile Include="BuilderTests\Using_a_custom_builder_to_work_with_a_list_property.cs" />
     <Compile Include="BuilderTests\When_building_two_consecutive_objects.cs" />

--- a/src/Fluency/FluentBuilder.cs
+++ b/src/Fluency/FluentBuilder.cs
@@ -222,6 +222,18 @@ namespace Fluency
             return this;
         }
 
+        /// <summary>
+        /// Mark a all properties to be ignored when setting of default values
+        /// </summary>
+        /// <exception cref="FluencyException"></exception>
+        protected internal FluentBuilder<T> IgnoreAllProperties()
+        {
+            if (_preBuiltResult != null)
+                throw new FluencyException("Cannot ignore properties once a pre built result has been given. Property change will have no affect.");
+            
+            _properties.Clear();            
+            return this;
+        }
 
         /// <summary>
         /// Sets the builder to be used to construct the value for the specified propety.

--- a/src/Fluency/FluentBuilder.cs
+++ b/src/Fluency/FluentBuilder.cs
@@ -236,6 +236,30 @@ namespace Fluency
         }
 
         /// <summary>
+        /// Mark a all non public properties to be ignored when setting of default values
+        /// </summary>
+        /// <exception cref="FluencyException"></exception>
+        protected internal FluentBuilder<T> IgnoreNonPublicSetters()
+        {
+            if (_preBuiltResult != null)
+                throw new FluencyException("Cannot ignore properties once a pre built result has been given. Property change will have no affect.");
+
+            foreach (var propertyInfo in typeof(T).GetProperties())
+            {
+                if (_properties.Contains(propertyInfo.Name))
+                {
+                    var methodInfo = propertyInfo.GetSetMethod(nonPublic: true);
+                    if (!methodInfo.IsPublic)
+                    {
+                        _properties.Remove(propertyInfo.Name);
+                    }
+                }                
+            }
+
+            return this;
+        }
+
+        /// <summary>
         /// Sets the builder to be used to construct the value for the specified propety.
         /// </summary>
         /// <typeparam name="TPropertyType">The type of the property type.</typeparam>

--- a/src/Fluency/FluentBuilder.cs
+++ b/src/Fluency/FluentBuilder.cs
@@ -204,14 +204,32 @@ namespace Fluency
 			return this;
 		}
 
+        /// <summary>
+        /// Mark a property to be ignored when setting of default values
+        /// </summary>
+        /// <typeparam name="TPropertyType">The type of the property type.</typeparam>
+        /// <param name="propertyExpression">The property expression.</param>
+        /// <exception cref="FluencyException"></exception>
+	    protected internal FluentBuilder<T> IgnoreProperty<TPropertyType>(
+	        Expression<Func<T, TPropertyType>> propertyExpression)
+        {
+            if (_preBuiltResult != null)
+                throw new FluencyException("Cannot ignore property once a pre built result has been given. Property change will have no affect.");
 
-		/// <summary>
-		/// Sets the builder to be used to construct the value for the specified propety.
-		/// </summary>
-		/// <typeparam name="TPropertyType">The type of the property type.</typeparam>
-		/// <param name="propertyExpression">The property expression.</param>
-		/// <param name="builder">The builder.</param>
-		protected internal FluentBuilder< T > SetProperty< TPropertyType >( Expression< Func< T, TPropertyType > > propertyExpression, IFluentBuilder builder )
+            var property = propertyExpression.GetPropertyInfo();
+
+            _properties.Remove(property.Name);
+            return this;
+        }
+
+
+        /// <summary>
+        /// Sets the builder to be used to construct the value for the specified propety.
+        /// </summary>
+        /// <typeparam name="TPropertyType">The type of the property type.</typeparam>
+        /// <param name="propertyExpression">The property expression.</param>
+        /// <param name="builder">The builder.</param>
+        protected internal FluentBuilder< T > SetProperty< TPropertyType >( Expression< Func< T, TPropertyType > > propertyExpression, IFluentBuilder builder )
 				where TPropertyType : class, new()
 		{
 			// Due to lack of polymorphism in generic parameters.


### PR DESCRIPTION
When using FluentBuilder<T> there are some objects that have validation in their constructors for certain values, or have logic in their setters that should not be triggered, or have private setters that should not be called.

This adds some features to customize builders to ignore certain setters.